### PR TITLE
Add minimal CI workflow placeholder on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Confirm CI is wired up
+        run: echo "CI configured. Build and test jobs run from feature-branch workflows."


### PR DESCRIPTION
## Summary
- Adds a minimal `.github/workflows/ci.yml` so GitHub Actions fires on push and pull_request against `master`
- The job is intentionally a no-op placeholder; feature-branch PRs (like the modernization branch) ship their own `ci.yml` that overrides this with the real build/test/lint pipeline

## Why
Without a workflow file on `master`, the default branch is "CI-unaware." The modernization PR (#3) targets `master`, but its workflow's `pull_request` trigger originally listed `[main]`, so it silently never fired. Landing this minimal placeholder on `master` ensures future PRs always trigger CI even before they bring their own workflow changes.

## Test plan
- [ ] Confirm the Smoke job runs on this PR
- [ ] Confirm the Smoke job runs on push to `master` after merge
- [ ] Confirm the modernization PR (#3) starts triggering its own (richer) workflow once its `[master]` trigger fix is in place

https://claude.ai/code/session_01Gqf38F1k7dPDMQCHJzNzHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqf38F1k7dPDMQCHJzNzHU)_